### PR TITLE
limit number of log messages stored and displayed

### DIFF
--- a/packages/outputconsole-extension/package.json
+++ b/packages/outputconsole-extension/package.json
@@ -14,7 +14,8 @@
   "author": "Project Jupyter",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "schema/*.json"
   ],
   "sideEffects": [
     "style/**/*"
@@ -34,6 +35,7 @@
   "dependencies": {
     "@jupyterlab/application": "^1.1.0-alpha.1",
     "@jupyterlab/apputils": "^1.1.0-alpha.1",
+    "@jupyterlab/coreutils": "^3.1.0-alpha.1",
     "@jupyterlab/docregistry": "^1.1.0-alpha.1",
     "@jupyterlab/mainmenu": "^1.1.0-alpha.1",
     "@jupyterlab/notebook": "^1.1.0-alpha.1",
@@ -50,6 +52,7 @@
     "access": "public"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   }
 }

--- a/packages/outputconsole-extension/schema/plugin.json
+++ b/packages/outputconsole-extension/schema/plugin.json
@@ -1,0 +1,16 @@
+{
+  "jupyter.lab.setting-icon-class": "jp-SettingsIcon",
+  "jupyter.lab.setting-icon-label": "Output Console",
+  "title": "Output Console",
+  "description": "Output Console settings.",
+  "properties": {
+    "maxLogEntries": {
+      "type": "number",
+      "title": "Log entry count limit",
+      "description": "Maximum number of log entries to store in memory",
+      "default": 1000
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/outputconsole-extension/tsconfig.json
+++ b/packages/outputconsole-extension/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../apputils"
     },
     {
+      "path": "../coreutils"
+    },
+    {
       "path": "../docregistry"
     },
     {

--- a/packages/outputconsole/src/index.tsx
+++ b/packages/outputconsole/src/index.tsx
@@ -113,6 +113,7 @@ export class OutputConsole implements IOutputConsole {
    */
   logMessage(payload: IOutputLogPayload) {
     this._messages.push(payload);
+    this._applyMessageLimit();
 
     this._signals.forEach(signal => {
       signal.emit(payload);
@@ -171,6 +172,34 @@ export class OutputConsole implements IOutputConsole {
   }
 
   /**
+   * Sets message entry limit.
+   */
+  set messageLimit(limit: number) {
+    if (limit > 0) {
+      this._messageLimit = limit;
+      this._applyMessageLimit();
+    }
+  }
+
+  /**
+   * Returns message entry limit.
+   */
+  get messageLimit(): number {
+    return this._messageLimit;
+  }
+
+  /**
+   * Apply message entry limit to message list.
+   */
+  private _applyMessageLimit() {
+    if (this._messages.length > this._messageLimit) {
+      this._messages = this._messages.slice(
+        this._messages.length - this._messageLimit
+      );
+    }
+  }
+
+  /**
    * Applies filter to a log message.
    * Returns true if message passes the filter.
    */
@@ -205,6 +234,7 @@ export class OutputConsole implements IOutputConsole {
   }
 
   private _messages: IOutputLogPayload[] = [];
+  private _messageLimit: number = 1000;
   private _signals: Map<
     string,
     Signal<IOutputConsole, IOutputLogPayload>


### PR DESCRIPTION
- limits number of messages stored in memory and displayed in the output console list
- default limit is 1000
- setting is exposed to user via `Advanced Settings Editor`

<img width="1082" alt="Output Console Settings" src="https://user-images.githubusercontent.com/40003442/63128718-4abb6f80-bfbe-11e9-8206-c8284b7bf439.png">
